### PR TITLE
[FEAT] provide a text only download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ Instead of showing complete, individual tweets with profile picture, date, etc. 
 ttm <last tweet url> -T
 ```
 
+### Text only
+With this flag, only the text of the tweet itself will be included. No author tags, frontmatter, or other information will be attached.
+
+Nota bene: This has not been tested well with threads. Please use at your own risk. Condensed threads may be a better fit for you.
+
 ### Custom File Name
 
 In order to save the tweet with a custom filename, pass the desired name to the `--filename` flag. You can use the variables `[[name]]`, `[[handle]]`, `[[text]]`, and `[[id]]` in your filename, which will be replaced according to the following chart. The file extension `.md` will also be added automatically.

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -301,4 +301,19 @@ Check it out! ✨
       options
     )
   })
+  it('Provides just the tweet text with textOnly option', async () => {
+    const options = {
+      bearer: BEARER_TOKEN,
+      src: singleUrlTweet.data.id,
+      textOnly: true,
+    }
+    await processTweetRequest(options)
+    expect(writeTweet).toBeCalledWith(
+      singleUrlTweet,
+      `After 4 months of release candidates we're proud to release version 1.0 of Tauri! 🎉 Windows, Menus, System Trays, Auto Updater and much more are now at your fingertips!
+
+Check it out! ✨
+[tauri.app](https://tauri.app/)`, options
+    )
+  })
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,6 +80,12 @@ const optionDefinitions: OptionDefinition[] = [
     description:
       'Save an entire tweet thread in a single document, but only show the author on the first tweet or on author changes. Use the link of the last tweet.',
   },
+  {
+    name: 'text_only',
+    alias: 'x',
+    type: Boolean,
+    description: 'Only save the text of the tweet, without author or any other metadata.'
+  }
 ]
 
 /**

--- a/src/process.ts
+++ b/src/process.ts
@@ -88,7 +88,7 @@ export const processTweetRequest = async (
     })
   )
   const firstTweet = tweets[0]
-  if (options.condensedThread) {
+  if (options.condensedThread && !options.textOnly) {
     markdowns.push(
       '',
       '',

--- a/src/util.ts
+++ b/src/util.ts
@@ -451,8 +451,9 @@ export const buildMarkdown = async (
   )
 
   const showAuthor =
-    (iscondensedThreadTweet && user.id !== previousAuthor.id) ||
-    !iscondensedThreadTweet
+    ((iscondensedThreadTweet && user.id !== previousAuthor.id) ||
+      !iscondensedThreadTweet) &&
+    !options.textOnly
 
   let metrics: string[] = []
   if (options.metrics) {
@@ -466,14 +467,16 @@ export const buildMarkdown = async (
   /**
    * Define the frontmatter as the name, handle, and source url
    */
-  const frontmatter = [
-    '---',
-    `author: "${user.name}"`,
-    `handle: "@${user.username}"`,
-    `source: "https://twitter.com/${user.username}/status/${tweet.data.id}"`,
-    ...metrics,
-    '---',
-  ]
+  const frontmatter = options.textOnly
+    ? []
+    : [
+        '---',
+        `author: "${user.name}"`,
+        `handle: "@${user.username}"`,
+        `source: "https://twitter.com/${user.username}/status/${tweet.data.id}"`,
+        ...metrics,
+        '---',
+      ]
 
   // if the user wants local assets, download them
   if (options.assets) {
@@ -530,7 +533,7 @@ export const buildMarkdown = async (
   }
 
   // add original tweet link to end of tweet if not a condensed thread
-  if (!options.condensedThread) {
+  if (!options.condensedThread && !options.textOnly) {
     markdown.push(
       '\n\n' +
         `[Tweet link](https://twitter.com/${user.username}/status/${tweet.data.id})`


### PR DESCRIPTION
Provides an option `-x` to generate markdown files with only the text content of the tweet. No frontmatter, author information, etc. is included.

Fixes #14