### PR TITLE
[FEAT] add dates to downloaded tweets and frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This command line tool allows you to quickly save a tweet in Markdown format. Th
 
 ## Installing
 
-⚠ **You'll need to have Node.js of at least `v10.x` to use this tool.**
+⚠ **You'll need to have Node.js of at least `v12.x` to use this tool.**
 
 You can install this CLI tool by running
 
@@ -197,6 +197,20 @@ ttm <tweet url> -a --assets-path "./images"
 ```
 
 Nota bene: Unfortunately, there is currently not a way to save gifs or videos from tweets using the v2 API.
+
+### Date locale
+
+Using the `--date_locale` option, you can pass a BCP 47 language code to have the date displayed in a specific locale. If you don't pass this option (or if you're using lower than Node 13), your computer's default locale will be used.
+
+Finding a complete list of these language codes is difficult, but here's a short list of examples:
+| Tag | Language |
+| --- | --- |
+| en | English |
+| en-US | American English |
+| es-MX | Mexican Spanish |
+| ta-IN | Indian Tamil |
+
+A more complete list can be found here: https://gist.github.com/typpo/b2b828a35e683b9bf8db91b5404f1bd1
 
 <!-- CONTRIBUTING -->
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -53,9 +53,10 @@ describe('End to end tests', () => {
 author: "Maggie Appleton 🧭"
 handle: "@Mappletons"
 source: "https://twitter.com/Mappletons/status/1292845757297557505"
+date: 2020-08-10T15:30:23.000Z
 ---
 ![Mappletons](https://pbs.twimg.com/profile_images/1079304561892966406/1AHsGSnz_normal.jpg)
-Maggie Appleton 🧭 ([@Mappletons](https://twitter.com/Mappletons))
+Maggie Appleton 🧭 ([@Mappletons](https://twitter.com/Mappletons)) - August 10, 2020, 11:30 AM
 
 
 "Dirt is matter out of place" - the loveliest definition of dirt you could hope for from anthropologist Mary Douglas in her classic 1966 book Purity and Danger
@@ -86,9 +87,10 @@ Illustrating & expanding on her main ideas: [maggieappleton.com/dirt](http://mag
 author: "Geoffrey Litt"
 handle: "@geoffreylitt"
 source: "https://twitter.com/geoffreylitt/status/1277645969975377923"
+date: 2020-06-29T16:51:51.000Z
 ---
 ![geoffreylitt](https://pbs.twimg.com/profile_images/722626068293763072/4erM-SPN_normal.jpg)
-Geoffrey Litt ([@geoffreylitt](https://twitter.com/geoffreylitt))
+Geoffrey Litt ([@geoffreylitt](https://twitter.com/geoffreylitt)) - June 29, 2020, 12:51 PM
 
 
 A theory about why tools like Airtable and Notion are so compelling: they provide a much-needed synthesis between the design philosophies of UNIX and Apple.
@@ -105,7 +107,7 @@ Short thread: [pic.twitter.com/YjOLsIGVRD](https://twitter.com/geoffreylitt/stat
 ---
 
 ![geoffreylitt](https://pbs.twimg.com/profile_images/722626068293763072/4erM-SPN_normal.jpg)
-Geoffrey Litt ([@geoffreylitt](https://twitter.com/geoffreylitt))
+Geoffrey Litt ([@geoffreylitt](https://twitter.com/geoffreylitt)) - June 29, 2020, 12:51 PM
 
 
 UNIX is still the best working example of "tools not apps": small sharp tools that the user can flexibly compose to meet their needs.
@@ -118,7 +120,7 @@ Once you've written a few bash pipelines, it's hard to be satisfied with disconn
 ---
 
 ![geoffreylitt](https://pbs.twimg.com/profile_images/722626068293763072/4erM-SPN_normal.jpg)
-Geoffrey Litt ([@geoffreylitt](https://twitter.com/geoffreylitt))
+Geoffrey Litt ([@geoffreylitt](https://twitter.com/geoffreylitt)) - June 29, 2020, 12:51 PM
 
 
 The problem is, while the roots are solid, the terminal as UI is extremely hostile to users, esp beginners. No discoverability, cryptic flags, lots of cruft and chaos.
@@ -145,9 +147,10 @@ The problem is, while the roots are solid, the terminal as UI is extremely hosti
 author: "Geoffrey Litt"
 handle: "@geoffreylitt"
 source: "https://twitter.com/geoffreylitt/status/1277645969975377923"
+date: 2020-06-29T16:51:51.000Z
 ---
 ![geoffreylitt](https://pbs.twimg.com/profile_images/722626068293763072/4erM-SPN_normal.jpg)
-Geoffrey Litt ([@geoffreylitt](https://twitter.com/geoffreylitt))
+Geoffrey Litt ([@geoffreylitt](https://twitter.com/geoffreylitt)) - June 29, 2020, 12:51 PM
 
 
 A theory about why tools like Airtable and Notion are so compelling: they provide a much-needed synthesis between the design philosophies of UNIX and Apple.
@@ -189,9 +192,10 @@ The problem is, while the roots are solid, the terminal as UI is extremely hosti
 author: "Rasmus Andersson"
 handle: "@rsms"
 source: "https://twitter.com/rsms/status/1543295680088662016"
+date: 2022-07-02T18:08:57.000Z
 ---
 ![rsms](https://pbs.twimg.com/profile_images/1432033002880520193/nuDFioj3_normal.jpg)
-Rasmus Andersson ([@rsms](https://twitter.com/rsms))
+Rasmus Andersson ([@rsms](https://twitter.com/rsms)) - July 2, 2022, 2:08 PM
 
 
 [@nevyn](https://twitter.com/nevyn) Flash was awesome in so many ways! Being proprietary closed-source software was not awesome though.
@@ -215,9 +219,10 @@ Rasmus Andersson ([@rsms](https://twitter.com/rsms))
 author: "Edil Medeiros 🚢 ✏️🏴‍☠️ 🧩"
 handle: "@jose_edil"
 source: "https://twitter.com/jose_edil/status/1538271708918034433"
+date: 2022-06-18T21:25:29.000Z
 ---
 ![jose_edil](https://pbs.twimg.com/profile_images/669315274353561600/eHheoab4_normal.jpg)
-Edil Medeiros 🚢 ✏️🏴‍☠️ 🧩 ([@jose_edil](https://twitter.com/jose_edil))
+Edil Medeiros 🚢 ✏️🏴‍☠️ 🧩 ([@jose_edil](https://twitter.com/jose_edil)) - June 18, 2022, 5:25 PM
 
 
 [@visualizevalue](https://twitter.com/visualizevalue) [@EvansNifty](https://twitter.com/EvansNifty) [@OzolinsJanis](https://twitter.com/OzolinsJanis) [@milanicreative](https://twitter.com/milanicreative) [@design_by_kp](https://twitter.com/design_by_kp) [@victor_bigfield](https://twitter.com/victor_bigfield) [@StartupIllustr](https://twitter.com/StartupIllustr) [@tracytangtt](https://twitter.com/tracytangtt) [@AlexMaeseJ](https://twitter.com/AlexMaeseJ) [@ash_lmb](https://twitter.com/ash_lmb) [@moina_abdul](https://twitter.com/moina_abdul) @Its_Prasa [@elliottaleksndr](https://twitter.com/elliottaleksndr) [@aaraalto](https://twitter.com/aaraalto) [@tanoseihito](https://twitter.com/tanoseihito) [@jeffkortenbosch](https://twitter.com/jeffkortenbosch) [@FerraroRoberto](https://twitter.com/FerraroRoberto) [@eneskartall](https://twitter.com/eneskartall) [@SachinRamje](https://twitter.com/SachinRamje) [@AidanYeep](https://twitter.com/AidanYeep) [@jozzua](https://twitter.com/jozzua) Here they are:
@@ -260,9 +265,10 @@ Edil Medeiros 🚢 ✏️🏴‍☠️ 🧩 ([@jose_edil](https://twitter.com/jo
 author: "Karey Higuera 🦈"
 handle: "@kbravh"
 source: "https://twitter.com/kbravh/status/1566771957646757889"
+date: 2022-09-05T12:55:18.000Z
 ---
 ![kbravh](https://pbs.twimg.com/profile_images/1539402405506334721/1V5Xt64P_normal.jpg)
-Karey Higuera 🦈 ([@kbravh](https://twitter.com/kbravh))
+Karey Higuera 🦈 ([@kbravh](https://twitter.com/kbravh)) - September 5, 2022, 8:55 AM
 
 
 I've been working through some bugs on Tweet to Markdown regarding text parsing and [#hashtags](https://twitter.com/hashtag/hashtags), HTML entities (&,%, etc.), and CJK characters in hashtags ([#9月5日](https://twitter.com/hashtag/9月5日)).
@@ -286,9 +292,10 @@ I never knew how poorly programming languages handled non-Latin characters 😕
 author: "Tauri"
 handle: "@TauriApps"
 source: "https://twitter.com/TauriApps/status/1537347873565773824"
+date: 2022-06-16T08:14:30.000Z
 ---
 ![TauriApps](https://pbs.twimg.com/profile_images/1427375984475578389/jWzgho1b_normal.png)
-Tauri ([@TauriApps](https://twitter.com/TauriApps))
+Tauri ([@TauriApps](https://twitter.com/TauriApps)) - June 16, 2022, 4:14 AM
 
 
 After 4 months of release candidates we're proud to release version 1.0 of Tauri! 🎉 Windows, Menus, System Trays, Auto Updater and much more are now at your fingertips!

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,6 +85,10 @@ const optionDefinitions: OptionDefinition[] = [
     alias: 'x',
     type: Boolean,
     description: 'Only save the text of the tweet, without author or any other metadata.'
+  },
+  {
+    name: 'date_locale',
+    description: 'The BCP 47 locale to use when displaying the date next to the author\'s name. E.g.: \'en-US\'. Defaults to your computer\'s locale.'
   }
 ]
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -119,3 +119,8 @@ export interface User {
   username: string
   profile_image_url: string
 }
+
+export type TimestampFormat = {
+  locale: string
+  format?: Intl.DateTimeFormatOptions
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,6 +12,7 @@ import {
   Mention,
   Poll,
   Tag,
+  TimestampFormat,
   Tweet,
   TweetURL,
   User,
@@ -415,6 +416,22 @@ export const testPath = async (path: string): Promise<string | void> =>
     )
   })
 
+export const formatTimestamp = (
+  timestamp: string,
+  timestampFormat: TimestampFormat
+): string =>
+  new Date(timestamp).toLocaleDateString(
+    timestampFormat.locale,
+    timestampFormat.format ?? {
+      day: 'numeric',
+      year: 'numeric',
+      month: 'long',
+      hour: 'numeric',
+      minute: 'numeric',
+      timeZoneName: 'short',
+    }
+  )
+
 /**
  * Creates the entire Markdown string of the provided tweet
  * @param {Tweet} tweet - The entire tweet object provided by the Twitter v2 API
@@ -464,6 +481,19 @@ export const buildMarkdown = async (
     ]
   }
 
+  const isoDate = new Date(tweet.data.created_at).toISOString()
+
+  const date = formatTimestamp(tweet.data.created_at, {
+    locale: options.dateLocale,
+    format: {
+      day: 'numeric',
+      year: 'numeric',
+      month: 'long',
+      hour: 'numeric',
+      minute: 'numeric',
+    },
+  })
+
   /**
    * Define the frontmatter as the name, handle, and source url
    */
@@ -474,6 +504,7 @@ export const buildMarkdown = async (
         `author: "${user.name}"`,
         `handle: "@${user.username}"`,
         `source: "https://twitter.com/${user.username}/status/${tweet.data.id}"`,
+        `date: ${isoDate}`,
         ...metrics,
         '---',
       ]
@@ -494,7 +525,7 @@ export const buildMarkdown = async (
             )
           : user.profile_image_url
       })`, // profile image
-      `${user.name} ([@${user.username}](https://twitter.com/${user.username}))`, // name and handle
+      `${user.name} ([@${user.username}](https://twitter.com/${user.username})) - ${date}`, // name and handle
       '\n',
       text
     )


### PR DESCRIPTION
I need to include the tweet date information in the generated markdown. This will bring the CLI closer to feature parity with the Obsidian plugin.

An obvious missing feature is allowing the user to define the date format. Unfortunately, `toLocaleDateString()` does not accept nice formats like every other date library. I will work on writing a wrapper, but in the meantime, it will just be a default.

Addresses #10 