### PR TITLE
feat:  add Thread Reader App link and the end

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -565,7 +565,7 @@ export const buildMarkdown = async (
     markdown = markdown.map(line => '> ' + line)
   }
 
-  // add original tweet link to end of tweet if not a condensed thread
+  // add original tweet link and Thread Reader App link to end of tweet if not a condensed thread
   if (
     !(options.condensedThread || options.semicondensedThread) &&
     !options.textOnly
@@ -573,6 +573,10 @@ export const buildMarkdown = async (
     markdown.push(
       '\n\n' +
         `[Tweet link](https://twitter.com/${user.username}/status/${tweet.data.id})`
+    )
+    markdown.push(
+      '\n\n' +
+        `[Thread by @${user.username} on Thread Reader App – Thread Reader App](https://threadreaderapp.com/thread/${tweet.data.id}.html)`
     )
   }
 


### PR DESCRIPTION
# What
- Add Thread Reader App and the end

Before 
```markdown
[Tweet link](https://twitter.com/mattpocockuk/status/1509964736275927042)
```

After
```markdown

[Tweet link](https://twitter.com/mattpocockuk/status/1509964736275927042)

[Thread by @mattpocockuk on Thread Reader App – Thread Reader App](https://threadreaderapp.com/thread/1509964736275927042.html)
```

# Why

- Integrate Thread Reader App to unroll the Twitter url

# How

- This may be not ideal solution as I searched `tweet link` on your repo then add below code.

```typescript
 markdown.push(
      '\n\n' +
        `[Thread by @${user.username} on Thread Reader App – Thread Reader App](https://threadreaderapp.com/thread/${tweet.data.id}.html)`
    )
```