### PR TITLE
Quote format fix and Retweeted

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -26,6 +26,15 @@ export const processTweetRequest = async (
 
   try {
     currentTweet = await getTweet(id, options.bearer)
+    // Get the original tweet instead of a retweet staring with RT @username
+    if (currentTweet.data && currentTweet.data.referenced_tweets) {
+      for (const tweet_ref of currentTweet.data.referenced_tweets) {
+        if (tweet_ref && tweet_ref.type === 'retweeted') {
+          currentTweet = await getTweet(tweet_ref.id, options.bearer)
+          process.stdout.write(`Retweeted tweets downloaded: ${tweets.length}\r`)
+        }
+      }
+    }
   } catch (err) {
     error = err
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -560,18 +560,13 @@ export const buildMarkdown = async (
     }
   }
 
-  // indent all lines for a quoted tweet
-  if (type === 'quoted') {
-    markdown = markdown.map(line => '> ' + line)
-  }
-
   // add original tweet link to end of tweet if not a condensed thread
   if (
     !(options.condensedThread || options.semicondensedThread) &&
     !options.textOnly
   ) {
+    markdown.push('')
     markdown.push(
-      '\n\n' +
         `[Tweet link](https://twitter.com/${user.username}/status/${tweet.data.id})`
     )
   }
@@ -582,7 +577,7 @@ export const buildMarkdown = async (
     case 'thread':
       return markdown.join('\n')
     case 'quoted':
-      return '\n\n' + markdown.join('\n')
+      return '\n\n> ' + markdown.join('\n> ')
     default:
       return '\n\n' + markdown.join('\n')
   }


### PR DESCRIPTION
Since the Twitter API still work I made some small fix:

1. Add quote format to the quoted tweet link as below:
```
Tweet text

> Quoted author
>
> Quoted Tweet text
>
> [Tweet link]

[Tweet link]
```
2. Get the original tweet instead of a retweet staring with RT @username, which is common when using `GET /2/users/:id/tweets` to fetch the tweets id